### PR TITLE
Support for about stateless action

### DIFF
--- a/cmd/qliksense/invoke.go
+++ b/cmd/qliksense/invoke.go
@@ -6,17 +6,22 @@ import (
 )
 
 func buildInvokeCommand(m *qliksense.Mixin) *cobra.Command {
+	var action string
 	cmd := &cobra.Command{
 		Use:   "invoke",
 		Short: "Execute the invoke functionality of this mixin",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return m.Execute()
+			switch action {
+			case "about":
+				return m.About()
+			default:
+				return m.Execute()
+			}
 		},
 	}
 
 	// Define a flag for --action so that its presence doesn't cause errors, but ignore it since exec doesn't need it
-	var action string
-	cmd.Flags().StringVar(&action, "action", "", "Custom action name to invoke.")
 
+	cmd.Flags().StringVar(&action, "action", "", "Custom action name to invoke.")
 	return cmd
 }

--- a/pkg/qliksense/about.go
+++ b/pkg/qliksense/about.go
@@ -29,7 +29,7 @@ type AboutArguments struct {
 }
 
 type VersionOutput struct {
-	QliksenseVersion string   `yaml:"qliksenseVersion"`
+	QliksenseVersion string   `yaml:"qlikSenseVersion"`
 	Images           []string `yaml:"images"`
 }
 

--- a/pkg/qliksense/about.go
+++ b/pkg/qliksense/about.go
@@ -1,0 +1,88 @@
+package qliksense
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	_ "os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// AboutAction The `Porter.sh` action for Qliksense About
+type AboutAction struct {
+	Steps []AboutStep `yaml:"about"`
+}
+
+// AboutStep The `Porter.sh` step for Install for Kustomize
+type AboutStep struct {
+	AboutArguments `yaml:"qliksense"`
+}
+
+// AboutArguments ...
+type AboutArguments struct {
+	Step    `yaml:",inline"`
+	Version string `yaml:"version"`
+}
+
+type VersionOutput struct {
+	QliksenseVersion string   `yaml:"qliksenseVersion"`
+	Images           []string `yaml:"images"`
+}
+
+// About The public method invoked by `porter` when performing an `Install` step that has a `qliksense` mixin step
+func (m *Mixin) About() error {
+	var (
+		payload          []byte
+		version          string
+		err              error
+		action           AboutAction
+		versionOut       VersionOutput
+		file             *os.File
+		realVersion, out []byte
+		scanner          *bufio.Scanner
+		images           []string
+	)
+
+	if payload, err = m.getPayloadData(); err != nil {
+		return err
+	}
+	if err = yaml.Unmarshal(payload, &action); err != nil {
+		return err
+	}
+	if len(action.Steps) != 1 {
+		return errors.Errorf("expected a single step, but got %d", len(action.Steps))
+	}
+
+	if version = action.Steps[0].AboutArguments.Version; version == "bundled" {
+		realVersion, err = ioutil.ReadFile(filepath.Join(chartCache, "VERSION"))
+
+		if file, err = os.Open(filepath.Join(chartCache, "images-"+string(realVersion)+".txt")); err != nil {
+			return err
+		}
+		defer file.Close()
+
+		scanner = bufio.NewScanner(file)
+		images = make([]string, 0)
+		for scanner.Scan() {
+			images = append(images, scanner.Text())
+		}
+		if err = scanner.Err(); err != nil {
+			return err
+		}
+		versionOut = VersionOutput{
+			QliksenseVersion: string(realVersion),
+			Images:           images,
+		}
+		if out, err = yaml.Marshal(versionOut); err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+	} else {
+		// TODO: Means we are fetching from Git
+	}
+	return nil
+}

--- a/pkg/qliksense/schema/qliksense.json
+++ b/pkg/qliksense/schema/qliksense.json
@@ -24,7 +24,21 @@
     "invokeStep": {
       "type": "object",
       "properties": {
-        "qliksense": {"$ref": "#/definitions/qliksense"}
+        "qliksense": {
+          "type": "object",
+          "properties": {
+            "version": {
+              "type": "string"
+            },
+            "description": {
+              "$ref": "#/definitions/stepDescription"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "version"
+          ]
+        }
       },
       "required": [
         "qliksense"


### PR DESCRIPTION
Looks for some files in chartcache put there by the build action (from helm) and spits out the result. FIles are `.chartcache/VERSION` and `.chartcache/images-$VERSION.txt`

Example output:
```
qliksenseVersion: 1.12.89
images:
- docker.io/bitnami/mongodb:3.6.12
- docker.io/bitnami/nats:1.3.0-debian-9
- docker.io/nats-streaming:0.11.2
- docker.io/oliver006/redis_exporter:v0.28.0
- qlik-docker-qsefe.bintray.io/audit:1.9.1
- qlik-docker-qsefe.bintray.io/chronos-worker:0.5.9
- qlik-docker-qsefe.bintray.io/chronos:0.9.15
- qlik-docker-qsefe.bintray.io/collections:1.0.85
- qlik-docker-qsefe.bintray.io/data-connector-odbc:6.29.0
- qlik-docker-qsefe.bintray.io/data-connector-qwc:0.62.0
- qlik-docker-qsefe.bintray.io/data-connector-rest:2.17.0
- qlik-docker-qsefe.bintray.io/data-connector-sfdc:15.12.0
- qlik-docker-qsefe.bintray.io/data-prep-service:2.141.0
- qlik-docker-qsefe.bintray.io/data-rest-source:1.0.4
- qlik-docker-qsefe.bintray.io/dcaas-web:1.1.31
- qlik-docker-qsefe.bintray.io/dcaas:1.6.25
- qlik-docker-qsefe.bintray.io/edge-auth:2.50.0
- qlik-docker-qsefe.bintray.io/encryption:3.1.10
- qlik-docker-qsefe.bintray.io/engine:12.460.0
- qlik-docker-qsefe.bintray.io/eventing:0.0.9
- qlik-docker-qsefe.bintray.io/feature-flags:1.1.0
- qlik-docker-qsefe.bintray.io/geo-operations-service:1.0.0
- qlik-docker-qsefe.bintray.io/groups:1.1.11
- qlik-docker-qsefe.bintray.io/hub:1.0.101
- qlik-docker-qsefe.bintray.io/identity-providers:0.1.6
- qlik-docker-qsefe.bintray.io/insights:1.0.9
- qlik-docker-qsefe.bintray.io/keys:1.0.2
- qlik-docker-qsefe.bintray.io/leader-elector:1.2
- qlik-docker-qsefe.bintray.io/leader-elector:1.3
- qlik-docker-qsefe.bintray.io/licenses:1.42.0
- qlik-docker-qsefe.bintray.io/locale:1.0.4
- qlik-docker-qsefe.bintray.io/management-console:2.118.0
- qlik-docker-qsefe.bintray.io/nats-streaming:0.14.2
- qlik-docker-qsefe.bintray.io/nginx-ingress-controller:1.4.8
- qlik-docker-qsefe.bintray.io/odag:1.21.0
- qlik-docker-qsefe.bintray.io/policy-decision-service:1.44.0
- qlik-docker-qsefe.bintray.io/precedents:0.63.0
- qlik-docker-qsefe.bintray.io/prometheus-nats-exporter:0.3.0
- qlik-docker-qsefe.bintray.io/qix-data-connection:1.12.1
- qlik-docker-qsefe.bintray.io/qix-data-reload:1.3.1
- qlik-docker-qsefe.bintray.io/qix-datafiles:1.0.0
- qlik-docker-qsefe.bintray.io/qix-sessions:3.2.8
- qlik-docker-qsefe.bintray.io/qnatsd:0.3.1
- qlik-docker-qsefe.bintray.io/quotas:0.7.0
- qlik-docker-qsefe.bintray.io/redis:4.0.12
- qlik-docker-qsefe.bintray.io/reload-tasks:0.1.12
- qlik-docker-qsefe.bintray.io/reporting-composer:1.0.0
- qlik-docker-qsefe.bintray.io/reporting-proxy:2.0.3
- qlik-docker-qsefe.bintray.io/reporting-service:4.1.0
- qlik-docker-qsefe.bintray.io/reporting-web-renderer:2.13.1
- qlik-docker-qsefe.bintray.io/resource-library:2.4.0
- qlik-docker-qsefe.bintray.io/sense-client:6.202.0
- qlik-docker-qsefe.bintray.io/spaces:1.7.2
- qlik-docker-qsefe.bintray.io/temporary-contents:1.3.3
- qlik-docker-qsefe.bintray.io/tenants:1.3.18
- qlik-docker-qsefe.bintray.io/users:1.13.6
- qlik/simple-oidc-provider:0.1.2
- qliktech-docker-snapshot.jfrog.io/prometheus-nats-exporter:0.1.0-16
```
Signed-off-by: Boris Kuschel <bkuschel@users.noreply.github.com>