### PR TITLE
Extracting images from k8s yaml based on output from running kustomize

### DIFF
--- a/pkg/qliksense/about.go
+++ b/pkg/qliksense/about.go
@@ -1,14 +1,15 @@
 package qliksense
 
 import (
-	"bufio"
+	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
-	_ "os/exec"
+	"log"
+	"os/exec"
 	"path/filepath"
+	"reflect"
+	"sort"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -27,7 +28,6 @@ type AboutArguments struct {
 	Step    `yaml:",inline"`
 	Version string `yaml:"version"`
 }
-
 type VersionOutput struct {
 	QliksenseVersion string   `yaml:"qlikSenseVersion"`
 	Images           []string `yaml:"images"`
@@ -36,17 +36,13 @@ type VersionOutput struct {
 // About The public method invoked by `porter` when performing an `Install` step that has a `qliksense` mixin step
 func (m *Mixin) About() error {
 	var (
-		payload          []byte
-		version          string
-		err              error
-		action           AboutAction
-		versionOut       VersionOutput
-		file             *os.File
-		realVersion, out []byte
-		scanner          *bufio.Scanner
-		images           []string
+		payload                       []byte
+		version                       string
+		err                           error
+		action                        AboutAction
+		versionOut                    VersionOutput
+		realVersion, out, kuzManifest []byte
 	)
-
 	if payload, err = m.getPayloadData(); err != nil {
 		return err
 	}
@@ -54,28 +50,20 @@ func (m *Mixin) About() error {
 		return err
 	}
 	if len(action.Steps) != 1 {
-		return errors.Errorf("expected a single step, but got %d", len(action.Steps))
+		return fmt.Errorf("expected a single step, but got %d", len(action.Steps))
 	}
-
 	if version = action.Steps[0].AboutArguments.Version; version == "bundled" {
-		realVersion, err = ioutil.ReadFile(filepath.Join(chartCache, "VERSION"))
-
-		if file, err = os.Open(filepath.Join(chartCache, "images-"+string(realVersion)+".txt")); err != nil {
+		if realVersion, err = ioutil.ReadFile(filepath.Join(chartCache, "VERSION")); err != nil {
+			log.Printf("error reading the VERSION file, error: %v\n", err)
 			return err
 		}
-		defer file.Close()
-
-		scanner = bufio.NewScanner(file)
-		images = make([]string, 0)
-		for scanner.Scan() {
-			images = append(images, scanner.Text())
-		}
-		if err = scanner.Err(); err != nil {
+		if kuzManifest, err = getKustomizeOutput(); err != nil {
+			log.Printf("error executing kustomize, error: %v\n", err)
 			return err
 		}
 		versionOut = VersionOutput{
 			QliksenseVersion: string(realVersion),
-			Images:           images,
+			Images:           getImageList(kuzManifest),
 		}
 		if out, err = yaml.Marshal(versionOut); err != nil {
 			return err
@@ -85,4 +73,58 @@ func (m *Mixin) About() error {
 		// TODO: Means we are fetching from Git
 	}
 	return nil
+}
+
+func getKustomizeOutput() ([]byte, error) {
+	cmd := exec.Command("kustomize", "build", "/cnab/app/manifests/docker-desktop")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Printf("executing kustomize process failed with error: %v, stderr: %v\n", err, string(stderr.Bytes()))
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+func getImageList(yamlContent []byte) []string {
+	decoder := yaml.NewDecoder(bytes.NewReader(yamlContent))
+	var resource map[string]interface{}
+	imageMap := make(map[string]bool)
+	captureContainerImages := func(path []string, val interface{}) {
+		if len(path) >= 2 && path[len(path)-1] == "image" &&
+			(path[len(path)-2] == "containers" || path[len(path)-2] == "initContainers") {
+			if image, ok := val.(string); ok {
+				imageMap[image] = true
+			}
+		}
+	}
+	for decoder.Decode(&resource) == nil {
+		traverseYamlDecodedMapRecursively(reflect.ValueOf(resource), []string{}, captureContainerImages)
+	}
+	var sortedImageList []string
+	for image, _ := range imageMap {
+		sortedImageList = append(sortedImageList, image)
+	}
+	sort.Strings(sortedImageList)
+	return sortedImageList
+}
+
+func traverseYamlDecodedMapRecursively(val reflect.Value, path []string, visitorFunc func(path []string, val interface{})) {
+	kind := val.Kind()
+	switch kind {
+	case reflect.Interface:
+		traverseYamlDecodedMapRecursively(val.Elem(), path, visitorFunc)
+	case reflect.Slice:
+		for i := 0; i < val.Len(); i++ {
+			traverseYamlDecodedMapRecursively(val.Index(i), path, visitorFunc)
+		}
+	case reflect.Map:
+		for _, key := range val.MapKeys() {
+			traverseYamlDecodedMapRecursively(val.MapIndex(key), append(path, key.Interface().(string)), visitorFunc)
+		}
+	default:
+		visitorFunc(path, val.Interface())
+	}
 }

--- a/pkg/qliksense/about_test.go
+++ b/pkg/qliksense/about_test.go
@@ -129,6 +129,9 @@ spec:
   containers:
   - name: nginx
     image: nginx
+    env:
+    - name: FOO
+      value: null 
     ports:
     - containerPort: 80
     volumeMounts:

--- a/pkg/qliksense/about_test.go
+++ b/pkg/qliksense/about_test.go
@@ -1,0 +1,159 @@
+package qliksense
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMixin_About_getImageList(t *testing.T) {
+	k8sYaml := `
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx-deployment-1
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: 2018-11-15T20:46:46Z
+  name: mysecret
+  namespace: default
+  resourceVersion: "7579"
+  uid: 91460ecb-e917-11e8-98f2-025000000001
+type: Opaque
+data:
+  username: YWRtaW5pc3RyYXRvcg==
+---
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx-deployment-2
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 3 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi
+spec:
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: init-demo
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+    volumeMounts:
+    - name: workdir
+      mountPath: /usr/share/nginx/html
+  # These containers are run during pod initialization
+  initContainers:
+  - name: install
+    image: busybox
+    command:
+    - wget
+    - "-O"
+    - "/work-dir/index.html"
+    - http://kubernetes.io
+    volumeMounts:
+    - name: workdir
+      mountPath: "/work-dir"
+  dnsPolicy: Default
+  volumes:
+  - name: workdir
+    emptyDir: {}
+`
+	images := getImageList([]byte(k8sYaml))
+	expectedImages := []string{"busybox", "k8s.gcr.io/nginx-slim:0.8", "nginx", "nginx:1.7.9", "perl"}
+	if !reflect.DeepEqual(images, expectedImages) {
+		t.Fatalf("expected %v, but got: %v\n", expectedImages, images)
+	}
+}

--- a/pkg/qliksense/build.go
+++ b/pkg/qliksense/build.go
@@ -2,33 +2,15 @@ package qliksense
 
 import (
 	"bufio"
-	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
-	"sync"
-	"time"
 
-	"gopkg.in/yaml.v2"
-
-	"github.com/gofrs/flock"
 	"github.com/pkg/errors"
-
-	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
+	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/cli"
-	"helm.sh/helm/v3/pkg/cli/values"
-	"helm.sh/helm/v3/pkg/downloader"
-	"helm.sh/helm/v3/pkg/getter"
-	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/releaseutil"
-	"helm.sh/helm/v3/pkg/repo"
-	"helm.sh/helm/v3/pkg/strvals"
 )
 
 // This is an example. Replace thie following with whatever steps are needed to
@@ -44,18 +26,10 @@ COPY --from=qlik/qliksense-cloud-tools:latest /usr/local/bin /usr/local/bin
 COPY --from=qlik/qliksense-operator:latest /usr/local/bin/qliksense-operator /usr/local/bin
 
 `
-	stableRepoName = "stable"
-	stableRepoURL  = "https://kubernetes-charts.storage.googleapis.com"
-	qlikRepoName   = "qlik"
-	qlikRepoURL    = "https://qlik.bintray.com/edge"
-	chartName      = "qliksense"
-	releaseName    = "release-name"
-	namespace      = "qliksense"
-	sets           = "devMode.enabled=true,engine.acceptEULA=\"yes\""
-	helmHomePrefix = "helmHome"
-	chartCache     = ".chartcache"
-	qseokVersion   = "QSEOK_VERSION"
-	porterFile     = "porter.yaml"
+	chartName    = "qliksense"
+	chartCache   = ".chartcache"
+	qseokVersion = "QSEOK_VERSION"
+	porterFile   = "porter.yaml"
 )
 
 var (
@@ -101,14 +75,13 @@ type helmChart struct {
 // for an invocation image using this mixin
 func (m *Mixin) Build() error {
 	var (
-		version, imagesFile, chartFile, scannedText string
-		err                                         error
-		createFile                                  bool
-		versionFile, porterDockerFile               *os.File
-		scanner                                     *bufio.Scanner
-		parts                                       []string
-		porterBytes                                 []byte
-		porterFileYaml                              porterYaml
+		version, chartFile, scannedText string
+		err                             error
+		versionFile, porterDockerFile   *os.File
+		scanner                         *bufio.Scanner
+		parts                           []string
+		porterBytes                     []byte
+		porterFileYaml                  porterYaml
 	)
 	if porterBytes, err = ioutil.ReadFile(porterFile); err != nil {
 		return err
@@ -145,33 +118,14 @@ func (m *Mixin) Build() error {
 		version, _ = GetTransformerVersion()
 	}
 	if len(version) > 0 {
-		imagesFile = filepath.Join(chartCache, "images-"+version+".txt")
 		if versionFile, err = os.Create(filepath.Join(chartCache, "VERSION")); err != nil {
 			return err
 		}
 		defer versionFile.Close()
 		versionFile.WriteString(version)
-	} else {
-		imagesFile = filepath.Join(chartCache, "images-latest.txt")
 	}
-	if _, err = os.Stat(imagesFile); err != nil {
-		if os.IsNotExist(err) {
-			createFile = true
-		} else {
-			return errors.Errorf("Unable to determine version file %v exists", imagesFile)
-		}
-	}
-	if _, err = os.Stat(chartFile); err != nil {
-		if os.IsNotExist(err) {
-			createFile = true
-		} else {
-			return errors.Errorf("Unable to determine chart file %v exists", chartFile)
-		}
-	}
-	if createFile {
-		if err = createImagesFile(version, imagesFile); err != nil {
-			return err
-		}
+	if _, err = os.Stat(chartFile); err != nil && !os.IsNotExist(err) {
+		return errors.Errorf("Unable to determine chart file %v exists", chartFile)
 	}
 
 	if len(version) > 0 {
@@ -182,341 +136,6 @@ func (m *Mixin) Build() error {
 		fmt.Fprintln(m.Out, strings.ReplaceAll("ADD "+filepath.Join(chartCache, helmDir, chartName+"-*.tgz")+" /tmp/.chartcache/", "\\", "/"))
 	}
 	return nil
-}
-
-func createImagesFile(version string, imagesFile string) error {
-	var image, helmHome string
-	var err error
-	var images []string
-	var file *os.File
-	var w *bufio.Writer
-
-	if helmHome, err = ioutil.TempDir("", helmHomePrefix); err != nil {
-		return err
-	}
-	defer os.RemoveAll(helmHome)
-
-	os.Setenv("HELM_NAMESPACE", namespace)
-	os.Setenv("XDG_CONFIG_HOME", helmHome)
-	os.Setenv("XDG_CACHE_HOME", chartCache)
-	settings = cli.New()
-
-	if err = repoAdd(stableRepoName, stableRepoURL); err != nil {
-		return err
-	}
-
-	if err = repoAdd(qlikRepoName, qlikRepoURL); err != nil {
-		return err
-	}
-
-	if err = repoUpdate(); err != nil {
-		return err
-	}
-	if file, err = os.Create(imagesFile); err != nil {
-		return err
-	}
-	defer file.Close()
-
-	w = bufio.NewWriter(file)
-	if images, err = getImages(releaseName, qlikRepoName, chartName, version, sets); err != nil {
-		return err
-	}
-	for _, image = range images {
-		fmt.Fprintln(w, image)
-	}
-	return w.Flush()
-}
-
-// RepoAdd adds repo with given name and url
-func repoAdd(name, url string) error {
-	var (
-		repoFile    = settings.RepositoryConfig
-		fileLock    *flock.Flock
-		lockContext context.Context
-		cancel      context.CancelFunc
-		locked      bool
-		err         error
-		b           []byte
-		f           repo.File
-		r           *repo.ChartRepository
-		c           = repo.Entry{
-			Name: name,
-			URL:  url,
-		}
-	)
-
-	if err = os.MkdirAll(filepath.Dir(repoFile), os.ModePerm); err != nil && !os.IsExist(err) {
-		return err
-	}
-
-	// Acquire a file lock for process synchronization
-	fileLock = flock.New(strings.Replace(repoFile, filepath.Ext(repoFile), ".lock", 1))
-
-	lockContext, cancel = context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	locked, err = fileLock.TryLockContext(lockContext, time.Second)
-	if err == nil && locked {
-		defer fileLock.Unlock()
-	}
-	if err != nil {
-		return err
-	}
-
-	if b, err = ioutil.ReadFile(repoFile); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if err = yaml.Unmarshal(b, &f); err != nil {
-		return err
-	}
-
-	if f.Has(name) {
-		//fmt.Printf("repository name (%s) already exists\n", name)
-		return nil
-	}
-
-	if r, err = repo.NewChartRepository(&c, getter.All(settings)); err != nil {
-		return err
-	}
-
-	if _, err = r.DownloadIndexFile(); err != nil {
-		return errors.Wrapf(err, "looks like %q is not a valid chart repository or cannot be reached", url)
-	}
-
-	f.Update(&c)
-
-	if err = f.WriteFile(repoFile, 0644); err != nil {
-		return err
-	}
-	return nil
-}
-
-// RepoUpdate updates charts for all helm repos
-func repoUpdate() error {
-	var (
-		repoFile = settings.RepositoryConfig
-		err      error
-		f        *repo.File
-		r        *repo.ChartRepository
-		repos    []*repo.ChartRepository
-		cfg      *repo.Entry
-		wg       sync.WaitGroup
-	)
-
-	f, err = repo.LoadFile(repoFile)
-	if os.IsNotExist(errors.Cause(err)) || len(f.Repositories) == 0 {
-		return errors.New("no repositories found. You must add one before updating")
-	}
-
-	for _, cfg = range f.Repositories {
-		r, err = repo.NewChartRepository(cfg, getter.All(settings))
-		if err != nil {
-			return err
-		}
-		repos = append(repos, r)
-	}
-
-	// fmt.Printf("Downloading helm chart index ...\n")
-	for _, r = range repos {
-		wg.Add(1)
-		go func(re *repo.ChartRepository) {
-			defer wg.Done()
-			if _, err = re.DownloadIndexFile(); err != nil {
-				// fmt.Printf("...Unable to get an update from the %q chart repository (%s):\n\t%s\n", re.Config.Name, re.Config.URL, err)
-			}
-		}(r)
-	}
-	wg.Wait()
-	return nil
-}
-
-// TemplateChart ...
-func getImages(name, repo, chart, version, args string) ([]string, error) {
-
-	var (
-		actionConfig   = new(action.Configuration)
-		client         = action.NewInstall(actionConfig)
-		err            error
-		validate       bool
-		rel            *release.Release
-		m              *release.Hook
-		manifests      bytes.Buffer
-		splitManifests map[string]string
-		manifest       string
-		any            = map[string]interface{}{}
-		images         = make([]string, 0)
-		k              string
-		v              interface{}
-	)
-
-	if err = actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
-		return images, err
-	}
-
-	client.DryRun = true
-	client.ReleaseName = releaseName
-	client.Replace = true // Skip the name check
-	client.ClientOnly = !validate
-	if len(version) > 0 {
-		client.Version = version
-	}
-	//	client.APIVersions = chartutil.VersionSet(extraAPIs)
-	if rel, err = runInstall(name, repo, chart, args, client); err != nil {
-		return images, err
-	}
-
-	fmt.Fprintln(&manifests, strings.TrimSpace(rel.Manifest))
-	for _, m = range rel.Hooks {
-		fmt.Fprintf(&manifests, "---\n# Source: %s\n%s\n", m.Path, m.Manifest)
-	}
-	// fmt.Printf("Building Image List ...\n")
-	splitManifests = releaseutil.SplitManifests(manifests.String())
-	for _, manifest = range splitManifests {
-		if err = yaml.Unmarshal([]byte(manifest), &any); err != nil {
-			return images, err
-		}
-		for k, v = range any {
-			images = searchImages(k, v, images)
-		}
-	}
-	// fmt.Printf("Done Image List\n")
-	return uniqueNonEmptyElementsOf(images), nil
-}
-
-func runInstall(name, repo, chartName, sets string, client *action.Install) (*release.Release, error) {
-	var (
-		valueOpts             = &values.Options{}
-		vals                  map[string]interface{}
-		p                     getter.Providers
-		cp                    string
-		validInstallableChart bool
-		err                   error
-		chartRequested        *chart.Chart
-		req                   []*chart.Dependency
-		man                   *downloader.Manager
-	)
-
-	debug("Original chart version: %q", client.Version)
-	if client.Version == "" && client.Devel {
-		debug("setting version to >0.0.0-0")
-		client.Version = ">0.0.0-0"
-	}
-
-	if cp, err = client.ChartPathOptions.LocateChart(fmt.Sprintf("%s/%s", repo, chartName), settings); err != nil {
-		return nil, err
-	}
-
-	debug("CHART PATH: %s\n", cp)
-
-	p = getter.All(settings)
-	if vals, err = valueOpts.MergeValues(p); err != nil {
-		return nil, err
-	}
-
-	// Add args
-	if err = strvals.ParseInto(sets, vals); err != nil {
-		return nil, errors.Wrap(err, "failed parsing --set data")
-	}
-	// Check chart dependencies to make sure all are present in /charts
-	// fmt.Printf("Downloading helm chart ...\n")
-	if chartRequested, err = loader.Load(cp); err != nil {
-		return nil, err
-	}
-
-	validInstallableChart, err = isChartInstallable(chartRequested)
-	if !validInstallableChart {
-		return nil, err
-	}
-
-	if req = chartRequested.Metadata.Dependencies; req != nil {
-		// If CheckDependencies returns an error, we have unfulfilled dependencies.
-		// As of Helm 2.4.0, this is treated as a stopping condition:
-		// https://github.com/helm/helm/issues/2209
-		if err = action.CheckDependencies(chartRequested, req); err != nil {
-			if client.DependencyUpdate {
-				man = &downloader.Manager{
-					Out:              os.Stdout,
-					ChartPath:        cp,
-					Keyring:          client.ChartPathOptions.Keyring,
-					SkipUpdate:       false,
-					Getters:          p,
-					RepositoryConfig: settings.RepositoryConfig,
-					RepositoryCache:  settings.RepositoryCache,
-				}
-				if err = man.Update(); err != nil {
-					return nil, err
-				}
-			} else {
-				return nil, err
-			}
-		}
-	}
-
-	client.Namespace = settings.Namespace()
-	return client.Run(chartRequested, vals)
-}
-
-func isChartInstallable(ch *chart.Chart) (bool, error) {
-	switch ch.Metadata.Type {
-	case "", "application":
-		return true, nil
-	}
-	return false, errors.Errorf("%s charts are not installable", ch.Metadata.Type)
-}
-
-func debug(format string, v ...interface{}) {
-	//format = fmt.Sprintf("[debug] %s\n", format)
-	//log.Output(2, fmt.Sprintf(format, v...))
-}
-
-func searchImages(key string, value interface{}, images []string) []string {
-	var (
-		submap     map[interface{}]interface{}
-		stringlist []interface{}
-		k, v       interface{}
-		ok         bool
-		i          int
-	)
-
-	submap, ok = value.(map[interface{}]interface{})
-	if ok {
-		for k, v = range submap {
-			images = searchImages(k.(string), v, images)
-		}
-		return images
-	}
-	stringlist, ok = value.([]interface{})
-	if ok {
-		images = searchImages("size", len(stringlist), images)
-		for i, v = range stringlist {
-			images = searchImages(fmt.Sprintf("%d", i), v, images)
-		}
-		return images
-	}
-
-	if key == "image" {
-		images = append(images, fmt.Sprintf("%v", value))
-	}
-	return images
-}
-
-func uniqueNonEmptyElementsOf(s []string) []string {
-	var (
-		unique = make(map[string]bool, len(s))
-		us     = make([]string, len(unique))
-		elem   string
-	)
-	for _, elem = range s {
-		if len(elem) != 0 {
-			if !unique[elem] {
-				us = append(us, elem)
-				unique[elem] = true
-			}
-		}
-	}
-	sort.Strings(us)
-	return us
 }
 
 // GetTransformerVersion ...

--- a/pkg/qliksense/schema/qliksense.json
+++ b/pkg/qliksense/schema/qliksense.json
@@ -32,11 +32,14 @@
             },
             "description": {
               "$ref": "#/definitions/stepDescription"
+            },
+            "profile": {
+              "type": "string"
             }
           },
           "additionalProperties": false,
           "required": [
-            "version"
+            "version", "profile"
           ]
         }
       },


### PR DESCRIPTION
```
MacBook-Pro:qliksense-k8s dlx$ porter invoke --action about
invoking custom action about on Qliksense...
executing about action from Qliksense (bundle instance: Qliksense)
Use bundled version by default
qlikSenseVersion: 1.21.23
images:
- alpine
- docker.io/bitnami/mongodb:3.6.12
- docker.io/bitnami/redis:4.0.12
- qlik-docker-qsefe.bintray.io/audit:1.15.3
- qlik-docker-qsefe.bintray.io/chronos-worker:0.5.10
- qlik-docker-qsefe.bintray.io/chronos:0.9.15
- qlik-docker-qsefe.bintray.io/collections:1.0.94
- qlik-docker-qsefe.bintray.io/data-connector-odbc:6.35.0
- qlik-docker-qsefe.bintray.io/data-connector-qwc:0.69.0
- qlik-docker-qsefe.bintray.io/data-connector-rest:2.21.0
- qlik-docker-qsefe.bintray.io/data-prep-service:2.160.0
- qlik-docker-qsefe.bintray.io/data-rest-source:1.0.4
- qlik-docker-qsefe.bintray.io/dcaas-web:1.1.57
- qlik-docker-qsefe.bintray.io/dcaas:1.6.27
- qlik-docker-qsefe.bintray.io/edge-auth:2.59.0
- qlik-docker-qsefe.bintray.io/encryption:3.1.11
- qlik-docker-qsefe.bintray.io/engine-qv:12.521.0
- qlik-docker-qsefe.bintray.io/engine:12.521.0
- qlik-docker-qsefe.bintray.io/eventing:0.0.11
- qlik-docker-qsefe.bintray.io/feature-flags:1.2.2
- qlik-docker-qsefe.bintray.io/generic-links:0.15.0
- qlik-docker-qsefe.bintray.io/geo-operations-service:1.1.0
- qlik-docker-qsefe.bintray.io/groups:1.2.0
- qlik-docker-qsefe.bintray.io/hub:1.0.123
- qlik-docker-qsefe.bintray.io/identity-providers:0.2.0
- qlik-docker-qsefe.bintray.io/insights:2.0.1
- qlik-docker-qsefe.bintray.io/keys:1.0.4
- qlik-docker-qsefe.bintray.io/leader-elector:1.3
- qlik-docker-qsefe.bintray.io/licenses:2.10.0
- qlik-docker-qsefe.bintray.io/locale:1.0.5
- qlik-docker-qsefe.bintray.io/management-console:2.211.0
- qlik-docker-qsefe.bintray.io/nats-streaming:0.14.2
- qlik-docker-qsefe.bintray.io/nginx-ingress-controller:1.4.9
- qlik-docker-qsefe.bintray.io/nl-broker:1.5.0
- qlik-docker-qsefe.bintray.io/nl-parser:0.36.0
- qlik-docker-qsefe.bintray.io/odag:1.27.0
- qlik-docker-qsefe.bintray.io/policy-decision-service:1.53.1
- qlik-docker-qsefe.bintray.io/precedents:0.70.0
- qlik-docker-qsefe.bintray.io/prometheus-nats-exporter:0.3.0
- qlik-docker-qsefe.bintray.io/qix-data-connection:1.12.19
- qlik-docker-qsefe.bintray.io/qix-data-reload:1.3.5
- qlik-docker-qsefe.bintray.io/qix-datafiles:1.0.11
- qlik-docker-qsefe.bintray.io/qix-sessions:5.0.10
- qlik-docker-qsefe.bintray.io/qlikview-client:12.50.2055
- qlik-docker-qsefe.bintray.io/qnatsd:0.3.1
- qlik-docker-qsefe.bintray.io/quotas:0.7.0
- qlik-docker-qsefe.bintray.io/reload-tasks:0.1.14
- qlik-docker-qsefe.bintray.io/reporting-composer:3.0.1
- qlik-docker-qsefe.bintray.io/reporting-proxy:2.1.0
- qlik-docker-qsefe.bintray.io/reporting-service:5.3.0
- qlik-docker-qsefe.bintray.io/reporting-web-renderer:2.15.0
- qlik-docker-qsefe.bintray.io/resource-library:2.8.0
- qlik-docker-qsefe.bintray.io/sense-client:6.264.0
- qlik-docker-qsefe.bintray.io/simple-oidc-provider:0.2.0
- qlik-docker-qsefe.bintray.io/spaces:1.10.2
- qlik-docker-qsefe.bintray.io/temporary-contents:1.3.3
- qlik-docker-qsefe.bintray.io/tenants:1.4.0
- qlik-docker-qsefe.bintray.io/users:1.14.6

execution completed successfully!
MacBook-Pro:qliksense-k8s dlx$ 

```